### PR TITLE
CreateIoCompletionPort key should be 0

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -81,7 +81,7 @@ int main (int argc, char ** argv) {
     SetLastError (0);
     hQuit = CreateEvent (NULL, TRUE, FALSE, NULL);
 
-    if (auto hIOCP = CreateIoCompletionPort (INVALID_HANDLE_VALUE, NULL, 0x1234, 0)) {
+    if (auto hIOCP = CreateIoCompletionPort (INVALID_HANDLE_VALUE, NULL, 0, 0)) {
 
         // create a lot of events
 


### PR DESCRIPTION
MSDN says

 > To create an I/O completion port without associating it, set the FileHandle parameter to INVALID_HANDLE_VALUE, the ExistingCompletionPort parameter to NULL, and **the CompletionKey parameter to zero** (which is ignored in this case). 